### PR TITLE
feat: format json generated doc

### DIFF
--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -55,6 +55,52 @@ const generateAPIDoc = async filePath => {
 
   let idx = 1
 
+  /**
+   * Template for the docs/README.md for the json parser
+   */
+  const tp = {
+    /**
+     * Check if a json value is empty
+     * @param { JSON } ct The hdg spec-collection.json value
+     */
+    isEmpty: ct => ct.length === 0 || Object.keys(ct).length === 0,
+    /**
+     * Return a prettier string for json values
+     * @param { String } key The hdg spec-collection.json key
+     * @param { String } ct The hdg spec-collection.json value
+     */
+    prettyJson: (key, ct) => {
+      return (
+        ` - ${key}:` + '\n```json\n' + JSON.stringify(ct, null, 2) + '\n```'
+      )
+    },
+    /**
+     * Return a prettier string for javascript values
+     * @param { String } key The hdg spec-collection.json key
+     * @param { String } ct The hdg spec-collection.json value
+     */
+    prettyJs: (key, ct) => ` - ${key}:` + '\n```javascript\n' + ct + '\n```',
+    url: (key, ct) => ` - ${key}: ${ct}`,
+    path: (key, ct) => ` - ${key}: ${ct}`,
+    method: (key, ct) => ` - ${key}: ${ct}`,
+    auth: (key, ct) => (ct === 'None' ? '' : ` - ${key}: ${ct}`),
+    httpUser: (key, ct) => ` - ${key}: ${ct}`,
+    httpPassword: (key, ct) => ` - ${key}: ${ct}`,
+    passwordFieldType: (key, ct) => ` - ${key}: ${ct}`,
+    bearerToken: (key, ct) => ` - ${key}: ${ct}`,
+    contentType: (key, ct) => ` - ${key}: ${ct}`,
+    requestType: (key, ct) => ` - ${key}: ${ct}`,
+    rawParams: (key, ct) => {
+      const parsed = JSON.parse(ct)
+      return tp.isEmpty(parsed) ? '' : tp.prettyJson(key, parsed)
+    },
+    headers: (key, ct) => (tp.isEmpty(ct) ? '' : tp.prettyJson(key, ct)),
+    params: (key, ct) => (tp.isEmpty(ct) ? '' : tp.prettyJson(key, ct)),
+    bodyParams: (key, ct) => (tp.isEmpty(ct) ? '' : tp.prettyJson(key, ct)),
+    preRequestScript: (key, ct) => tp.prettyJs(key, ct),
+    testScript: (key, ct) => tp.prettyJs(key, ct)
+  }
+
   data.forEach(item => {
     idx++
     apiDoc[idx] = `## ${item.name}`
@@ -62,11 +108,15 @@ const generateAPIDoc = async filePath => {
       idx++
       apiDoc[idx] = `### ${request.name}`
       Object.keys(request)
-        .filter(key => key !== 'name')
+        .filter(key => tp[key] && request[key])
         .forEach(key => {
-          if (request[key]) {
+          try {
             idx++
-            apiDoc[idx] = `- ${key}: ${request[key]}`
+            apiDoc[idx] = tp[key](key, request[key])
+          } catch (err) {
+            logError(
+              `\n Check key: ${key}. Make sure that postwoman-collection.json schema is correct`
+            )
           }
         })
       idx++


### PR DESCRIPTION
### Features:
 - Change the output string of the generated markdown (docs/REAMDE.md) using the default styles of vuepress
 - Fix lost nested object values at the parsing process

#### before
>Current master request `localhost:8080` snapshot. All nested object data are lost
![upstream](https://user-images.githubusercontent.com/4117768/91642797-a65b6e00-ea04-11ea-9792-5e84a372bd1c.png)

#### after
> In this pr `localhost:8080` snapshot using the same `hoppscotch-collection.json`
![master](https://user-images.githubusercontent.com/4117768/91642805-ace9e580-ea04-11ea-99df-73e175c299fc.png)